### PR TITLE
Change hex cache key to hex instead of build

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
       id: hex-cache
       with:
         path: ~/.hex
-        key: build-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        key: hex-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
 
     # Retries force a recompile but only if flag isn't
     - name: Clean to rule out incremental build as a source of flakiness


### PR DESCRIPTION
### Why:
To make it easier to spot and understand which cache is each.

### This addresses the issue by:
Changing hex cache key from build to hex.