### PR TITLE
Add restore keys to cache actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Setup Elixir Project
-        uses: ./.github/actions/elixir_setup
+        uses: utrustdev/action-setup-elixir@v2
         with:
           elixir-version: ${{ matrix.elixir }}
           otp-version: ${{ matrix.otp }}

--- a/action.yml
+++ b/action.yml
@@ -77,6 +77,8 @@ runs:
       with:
         path: deps/
         key: deps-${{ inputs.cache-key }}-${{ runner.os }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          deps-${{ inputs.cache-key }}-${{ runner.os }}-
 
     - name: Get build cache
       uses: actions/cache@v3
@@ -84,6 +86,8 @@ runs:
       with:
         path: _build/${{env.MIX_ENV}}/
         key: build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          build-${{ inputs.cache-key }}-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ env.MIX_ENV }}-
 
     - name: Get Hex cache
       uses: actions/cache@v3
@@ -91,6 +95,8 @@ runs:
       with:
         path: ~/.hex
         key: hex-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-${{ hashFiles('**/mix.lock') }}
+        restore-keys: |
+          hex-${{ runner.os }}-${{ inputs.otp-version }}-${{ inputs.elixir-version }}-
 
     # Retries force a recompile but only if flag isn't
     - name: Clean to rule out incremental build as a source of flakiness


### PR DESCRIPTION
### Why:
While we were getting exact hits to restore cache when dependencies were not updated, when there was a small dependency bump, we would need to download and recompile the whole project. To avoid doing that, we should restore the cache most of the times, and only compile new changes.

### This addresses the issue by:
- Adding `restore-keys` parameter to all caches
    -  The idea is to restore cache if the runner os, elixir and erlang versions are the same and turning dependencies exact match being optional